### PR TITLE
Fix: social.dm safety warning

### DIFF
--- a/src/classes/ribbon/index.ts
+++ b/src/classes/ribbon/index.ts
@@ -760,6 +760,9 @@ export class Ribbon {
       }
       case "server.migrated":
         break;
+      case "social.dm": {
+        this.emitter.emit("unsafe__social.dm", (msg as any).data)
+      }
     }
 
     this.emitter.emit(msg.command, (msg as any).data);

--- a/src/classes/ribbon/index.ts
+++ b/src/classes/ribbon/index.ts
@@ -760,9 +760,6 @@ export class Ribbon {
       }
       case "server.migrated":
         break;
-      case "social.dm": {
-        this.emitter.emit("unsafe__social.dm", (msg as any).data)
-      }
     }
 
     this.emitter.emit(msg.command, (msg as any).data);

--- a/src/classes/social/index.ts
+++ b/src/classes/social/index.ts
@@ -354,7 +354,7 @@ export class Social {
       const res = await this.#client.wrap(
         "social.dm",
         { recipient: userID, msg: message },
-        "social.dm",
+        "unsafe__social.dm",
         ["social.dm.fail", "staff.spam", "client.error"]
       );
 


### PR DESCRIPTION
Fixes two issues:
* The client now re-emits `social.dm` as `unsafe__social.dm` in accordance with the logged warning
* The `wrap` call within `Social#dm` now listens for `unsafe__social.dm` instead of `social.dm`, suppressing the incorrect logged warning